### PR TITLE
Outlines tests for request routing 

### DIFF
--- a/crc_jupyter_auth/remote_user_auth.py
+++ b/crc_jupyter_auth/remote_user_auth.py
@@ -36,7 +36,7 @@ class RemoteUserLoginHandler(BaseHandler):
         # Multiple roles are delimited by a semicolon
         header_vpn = self.authenticator.header_vpn
         remote_roles = self.request.headers.get(header_vpn, "").strip().split(';')
-        if self.authenticator.required_vpn_role in remote_roles:
+        if self.authenticator.required_vpn_role not in remote_roles:
             self.redirect(self.authenticator.vpn_redirect)
 
         # Require the user has an existing home directory

--- a/tests/test_remote_user_login_handler.py
+++ b/tests/test_remote_user_login_handler.py
@@ -1,0 +1,39 @@
+"""Test HTTP request routing by the ``RemoteUserLoginHandler`` class."""
+
+from unittest import TestCase
+
+from jupyterhub.objects import Server
+from tornado.httputil import HTTPServerRequest, HTTPHeaders, HTTPConnection
+from tornado.web import Application
+
+from crc_jupyter_auth.remote_user_auth import RemoteUserLoginHandler, RemoteUserAuthenticator
+
+
+class RequestRouting(TestCase):
+    """Test the routing of HTTP authentication requests"""
+
+    @staticmethod
+    def create_http_request(authenticator, header_data):
+        """Create a mock application and an HTTP request for that application"""
+
+        # Create a tornado application running a jupyterhub server
+        application = Application(hub=Server(), authenticator=authenticator)
+
+        # HTTP connections are used by the application to write HTTP responses
+        # The `set_close_callback` method is required to exist by JupyterHub
+        connection = HTTPConnection()
+        connection.set_close_callback = lambda x: None
+
+        # Return an HTTP request reflecting the given header data
+        headers = HTTPHeaders(header_data)
+        request = HTTPServerRequest(headers=headers, connection=connection)
+        return application, request
+
+    # This isn't a real test. I just need something to run the create_http_request
+    # while I figure out the tornado / jupyter frameworks
+    def runTest(self) -> None:
+        authenticator = RemoteUserAuthenticator()
+        application, request = self.create_http_request(authenticator, {'Cn': 'username'})
+        request_handler = RemoteUserLoginHandler(application=application, request=request)
+
+        request_handler.get()

--- a/tests/test_request_routing.py
+++ b/tests/test_request_routing.py
@@ -10,7 +10,11 @@ from tornado import web
 from tornado.httputil import HTTPServerRequest, HTTPHeaders, HTTPConnection
 from tornado.web import Application
 
-from crc_jupyter_auth.remote_user_auth import RemoteUserLoginHandler, RemoteUserAuthenticator, RemoteUserLocalAuthenticator
+from crc_jupyter_auth.remote_user_auth import (
+    RemoteUserLoginHandler,
+    RemoteUserAuthenticator,
+    RemoteUserLocalAuthenticator
+)
 
 
 class RequestRouting(TestCase):
@@ -64,7 +68,7 @@ class RequestRouting(TestCase):
 
         self.assertEqual(401, request_handler.get_status())
 
-    def test_missing_vpn_role_redirect(self) -> None:
+    def test_missing_vpn_role(self) -> None:
         """Test users are redirected to the ``vpn_redirect`` url for missing VPN roles"""
 
         authenticator = RemoteUserAuthenticator()
@@ -75,7 +79,7 @@ class RequestRouting(TestCase):
         destination = request_handler._headers['Location']
         self.assertEqual(authenticator.vpn_redirect, destination)
 
-    def test_incorrect_vpn_role_redirect(self) -> None:
+    def test_incorrect_vpn_role(self) -> None:
         """Test users are redirected to the ``vpn_redirect`` url for incorrect VPN roles"""
 
         authenticator = RemoteUserAuthenticator()

--- a/tests/test_request_routing.py
+++ b/tests/test_request_routing.py
@@ -8,7 +8,7 @@ from tornado import web
 from tornado.httputil import HTTPServerRequest, HTTPHeaders, HTTPConnection
 from tornado.web import Application
 
-from crc_jupyter_auth.remote_user_auth import RemoteUserLoginHandler, RemoteUserAuthenticator
+from crc_jupyter_auth.remote_user_auth import RemoteUserLoginHandler, RemoteUserAuthenticator, RemoteUserLocalAuthenticator
 
 
 class RequestRouting(TestCase):
@@ -82,3 +82,24 @@ class RequestRouting(TestCase):
         """Test valid authentication attempts are redirected to the JupyterHub URL"""
 
         raise NotImplementedError
+
+
+class HandlerRegistration(TestCase):
+    """Test authentication classes use the ``RemoteUserLoginHandler`` to route login requests"""
+
+    def run_test_on_authenticator(self, authenticator: Authenticator) -> None:
+        """Assert the given authenticator routes ``/login`` traffic using the ``RemoteUserLoginHandler`` class"""
+
+        handlers_list = authenticator.get_handlers(app=None)
+        handlers_dict = dict(*zip(handlers_list))
+        self.assertIs(RemoteUserLoginHandler, handlers_dict['/login'])
+
+    def test_remote_user_authenticator(self) -> None:
+        """Test the ``RemoteUserAuthenticator`` routes traffic using the ``RemoteUserLoginHandler`` handler"""
+
+        self.run_test_on_authenticator(RemoteUserAuthenticator())
+
+    def test_remote_user_local_authenticator(self) -> None:
+        """Test the ``RemoteUserLocalAuthenticator`` routes traffic using the ``RemoteUserLoginHandler`` handler"""
+
+        self.run_test_on_authenticator(RemoteUserLocalAuthenticator())

--- a/tests/test_request_routing.py
+++ b/tests/test_request_routing.py
@@ -140,12 +140,12 @@ class HandlerRegistration(TestCase):
         handlers_dict = dict(*zip(handlers_list))
         self.assertIs(RemoteUserLoginHandler, handlers_dict['/login'])
 
-    def test_remote_user_authenticator(self) -> None:
+    def test_user_authenticator(self) -> None:
         """Test the ``RemoteUserAuthenticator`` routes traffic using the ``RemoteUserLoginHandler`` handler"""
 
         self.run_test_on_authenticator(RemoteUserAuthenticator())
 
-    def test_remote_user_local_authenticator(self) -> None:
+    def test_local_authenticator(self) -> None:
         """Test the ``RemoteUserLocalAuthenticator`` routes traffic using the ``RemoteUserLoginHandler`` handler"""
 
         self.run_test_on_authenticator(RemoteUserLocalAuthenticator())


### PR DESCRIPTION
This PR is a first pass at adding a test suite. I'm still figuring out some of the nuances to the JupyterHub plugin framework so not all the tests pass. However, I have outlined all of the tests I think we'll need to run.

Two major things I have not figured out:

1. I'm checking the ultimate destination of the redirected handler by inspecting the `_headers['Location']` attribute. This needs to be replaced with an approach that doesn't access private attributes.
2. I wrote the `create_http_request_handler` to create a mock `RemoteUserLoginHandler` instance. Unfortunately, the returned instance doesn't work properly. Specifically, it doesn't instantiate objects in a way where the traitlets become functional. Looking at the `traitlets` documentation, the class needs to be a subclass of the `traitlets.HasTraits` class for traitlets to become functional. I'm not sure if this is added by JupyterHub automatically, or if we need to manually add it here. Going off the original [jhub_remote_user_authenticator](https://github.com/cwaldbieser/jhub_remote_user_authenticator) code, I think its the former but I'm not sure.