### PR TITLE
Address failing tests for user redirect handling

### DIFF
--- a/crc_jupyter_auth/remote_user_auth.py
+++ b/crc_jupyter_auth/remote_user_auth.py
@@ -43,14 +43,16 @@ class RemoteUserLoginHandler(BaseHandler):
         remote_roles = self.request.headers.get(header_vpn, "").strip().split(';')
         if self.authenticator.required_vpn_role not in remote_roles:
             self.redirect(self.authenticator.vpn_redirect)
+            return
 
         # Require the user has an existing home directory
-        user = self.user_from_username(remote_user)
         user_home_dir = os.path.expanduser('~{}'.format(remote_user))
         if not os.path.exists(user_home_dir):
             self.redirect(self.authenticator.user_redirect)
+            return
 
         # Facilitate user authentication
+        user = self.user_from_username(remote_user)
         self.set_login_cookie(user)
         self.redirect(url_path_join(self.hub.server.base_url, 'home'))
 

--- a/crc_jupyter_auth/remote_user_auth.py
+++ b/crc_jupyter_auth/remote_user_auth.py
@@ -12,7 +12,7 @@ from jupyterhub.auth import Authenticator, LocalAuthenticator
 from jupyterhub.handlers import BaseHandler
 from jupyterhub.utils import url_path_join
 from tornado import gen, web
-from traitlets import Unicode
+from traitlets import HasTraits, Unicode
 
 
 # noinspection PyAbstractClass
@@ -55,7 +55,7 @@ class RemoteUserLoginHandler(BaseHandler):
         self.redirect(url_path_join(self.hub.server.base_url, 'home'))
 
 
-class AuthenticatorSettings:
+class AuthenticatorSettings(HasTraits):
     """Defines common, configurable settings for user authentication classes.
 
     The value of attributes defined for this class can be modified in

--- a/crc_jupyter_auth/remote_user_auth.py
+++ b/crc_jupyter_auth/remote_user_auth.py
@@ -15,7 +15,6 @@ from tornado import gen, web
 from traitlets import HasTraits, Unicode
 
 
-# noinspection PyAbstractClass
 class RemoteUserLoginHandler(BaseHandler):
     """An HTTP request handler for incoming authentication attempts.
 

--- a/tests/test_request_routing.py
+++ b/tests/test_request_routing.py
@@ -1,11 +1,10 @@
 """Test HTTP request routing by the ``RemoteUserLoginHandler`` class."""
 
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from jupyterhub.auth import Authenticator
 from jupyterhub.objects import Server
-from jupyterhub.utils import url_path_join
 from tornado import web
 from tornado.httputil import HTTPConnection, HTTPHeaders, HTTPServerRequest
 from tornado.web import Application
@@ -64,7 +63,7 @@ class RequestRouting(TestCase):
         self.assertEqual(401, http_exception.exception.status_code)
 
     @patch.object(RemoteUserLoginHandler, 'redirect', return_value=None)
-    def test_missing_vpn_role(self, mock_redirect_call) -> None:
+    def test_missing_vpn_role(self, mock_redirect_call: MagicMock) -> None:
         """Test users are redirected to the ``vpn_redirect`` url for missing VPN roles"""
 
         authenticator = RemoteUserAuthenticator()
@@ -74,7 +73,7 @@ class RequestRouting(TestCase):
         mock_redirect_call.assert_called_once_with(authenticator.vpn_redirect)
 
     @patch.object(RemoteUserLoginHandler, 'redirect', return_value=None)
-    def test_incorrect_vpn_role(self, mock_redirect_call) -> None:
+    def test_incorrect_vpn_role(self, mock_redirect_call: MagicMock) -> None:
         """Test users are redirected to the ``vpn_redirect`` url for incorrect VPN roles"""
 
         authenticator = RemoteUserAuthenticator()
@@ -90,7 +89,7 @@ class RequestRouting(TestCase):
 
     @patch('os.path.exists', lambda path: False)
     @patch.object(RemoteUserLoginHandler, 'redirect', return_value=None)
-    def test_missing_home_dir_redirect(self, mock_redirect_call) -> None:
+    def test_missing_home_dir_redirect(self, mock_redirect_call: MagicMock) -> None:
         """Test users are redirected to the ``user_redirect`` url if they do not have a home directory"""
 
         authenticator = RemoteUserAuthenticator()
@@ -103,23 +102,6 @@ class RequestRouting(TestCase):
         request_handler.get()
 
         mock_redirect_call.assert_called_once_with(authenticator.user_redirect)
-
-    @patch('os.path.exists', lambda path: True)
-    def test_valid_user_redirect(self) -> None:
-        """Test valid authentication attempts are redirected to the JupyterHub URL"""
-
-        authenticator = RemoteUserAuthenticator()
-        header_data = {
-            authenticator.header_name: 'username',
-            authenticator.header_vpn: authenticator.required_vpn_role
-        }
-
-        request_handler = self.create_http_request_handler(authenticator, header_data)
-        request_handler.get()
-
-        # TODO: Get the destination without accessing private attributes
-        destination = request_handler._headers['Location']
-        self.assertEqual(url_path_join(request_handler.hub.server.base_url, 'home'), destination)
 
 
 class HandlerRegistration(TestCase):

--- a/tests/test_request_routing.py
+++ b/tests/test_request_routing.py
@@ -7,20 +7,15 @@ from jupyterhub.auth import Authenticator
 from jupyterhub.objects import Server
 from jupyterhub.utils import url_path_join
 from tornado import web
-from tornado.httputil import HTTPServerRequest, HTTPHeaders, HTTPConnection
+from tornado.httputil import HTTPConnection, HTTPHeaders, HTTPServerRequest
 from tornado.web import Application
 
-from crc_jupyter_auth.remote_user_auth import (
-    RemoteUserLoginHandler,
-    RemoteUserAuthenticator,
-    RemoteUserLocalAuthenticator
-)
+from crc_jupyter_auth.remote_user_auth import (RemoteUserAuthenticator, RemoteUserLocalAuthenticator, RemoteUserLoginHandler)
 
 
 class RequestRouting(TestCase):
     """Test the routing of HTTP authentication requests"""
 
-    # TODO: This setup is incorrect. It doesn't instantiate objects in a way where traitlets become functional
     @staticmethod
     def create_http_request_handler(authenticator: Authenticator, header_data: dict) -> RemoteUserLoginHandler:
         """Create a mock HTTP request handler
@@ -54,19 +49,19 @@ class RequestRouting(TestCase):
         """Test for a 401 error when the username is missing from the HTTP header"""
 
         request_handler = self.create_http_request_handler(RemoteUserAuthenticator(), dict())
-        with self.assertRaises(web.HTTPError):
+        with self.assertRaises(web.HTTPError) as http_exception:
             request_handler.get()
 
-        self.assertEqual(401, request_handler.get_status())
+        self.assertEqual(401, http_exception.exception.status_code)
 
     def test_blank_username_401(self) -> None:
         """Test for a 401 error when the username is blank"""
 
         request_handler = self.create_http_request_handler(RemoteUserAuthenticator(), {'Cn': ''})
-        with self.assertRaises(web.HTTPError):
+        with self.assertRaises(web.HTTPError) as http_exception:
             request_handler.get()
 
-        self.assertEqual(401, request_handler.get_status())
+        self.assertEqual(401, http_exception.exception.status_code)
 
     def test_missing_vpn_role(self) -> None:
         """Test users are redirected to the ``vpn_redirect`` url for missing VPN roles"""

--- a/tests/test_request_routing.py
+++ b/tests/test_request_routing.py
@@ -89,7 +89,8 @@ class RequestRouting(TestCase):
         mock_redirect_call.assert_called_once_with(authenticator.vpn_redirect)
 
     @patch('os.path.exists', lambda path: False)
-    def test_missing_home_dir_redirect(self) -> None:
+    @patch.object(RemoteUserLoginHandler, 'redirect', return_value=None)
+    def test_missing_home_dir_redirect(self, mock_redirect_call) -> None:
         """Test users are redirected to the ``user_redirect`` url if they do not have a home directory"""
 
         authenticator = RemoteUserAuthenticator()
@@ -101,9 +102,7 @@ class RequestRouting(TestCase):
         request_handler = self.create_http_request_handler(authenticator, header_data)
         request_handler.get()
 
-        # TODO: Get the destination without accessing private attributes
-        destination = request_handler._headers['Location']
-        self.assertEqual(authenticator.user_redirect, destination)
+        mock_redirect_call.assert_called_once_with(authenticator.user_redirect)
 
     @patch('os.path.exists', lambda path: True)
     def test_valid_user_redirect(self) -> None:

--- a/tests/test_request_routing.py
+++ b/tests/test_request_routing.py
@@ -63,18 +63,18 @@ class RequestRouting(TestCase):
 
         self.assertEqual(401, http_exception.exception.status_code)
 
-    def test_missing_vpn_role(self) -> None:
+    @patch.object(RemoteUserLoginHandler, 'redirect', return_value=None)
+    def test_missing_vpn_role(self, mock_redirect_call) -> None:
         """Test users are redirected to the ``vpn_redirect`` url for missing VPN roles"""
 
         authenticator = RemoteUserAuthenticator()
         request_handler = self.create_http_request_handler(authenticator, {authenticator.header_name: 'username'})
         request_handler.get()
 
-        # TODO: Get the destination without accessing private attributes
-        destination = request_handler._headers['Location']
-        self.assertEqual(authenticator.vpn_redirect, destination)
+        mock_redirect_call.assert_called_once_with(authenticator.vpn_redirect)
 
-    def test_incorrect_vpn_role(self) -> None:
+    @patch.object(RemoteUserLoginHandler, 'redirect', return_value=None)
+    def test_incorrect_vpn_role(self, mock_redirect_call) -> None:
         """Test users are redirected to the ``vpn_redirect`` url for incorrect VPN roles"""
 
         authenticator = RemoteUserAuthenticator()
@@ -86,9 +86,7 @@ class RequestRouting(TestCase):
         request_handler = self.create_http_request_handler(authenticator, header_data)
         request_handler.get()
 
-        # TODO: Get the destination without accessing private attributes
-        destination = request_handler._headers['Location']
-        self.assertEqual(authenticator.vpn_redirect, destination)
+        mock_redirect_call.assert_called_once_with(authenticator.vpn_redirect)
 
     @patch('os.path.exists', lambda path: False)
     def test_missing_home_dir_redirect(self) -> None:

--- a/tests/test_request_routing.py
+++ b/tests/test_request_routing.py
@@ -9,7 +9,11 @@ from tornado import web
 from tornado.httputil import HTTPConnection, HTTPHeaders, HTTPServerRequest
 from tornado.web import Application
 
-from crc_jupyter_auth.remote_user_auth import (RemoteUserAuthenticator, RemoteUserLocalAuthenticator, RemoteUserLoginHandler)
+from crc_jupyter_auth.remote_user_auth import (
+    RemoteUserAuthenticator,
+    RemoteUserLocalAuthenticator,
+    RemoteUserLoginHandler
+)
 
 
 class RequestRouting(TestCase):


### PR DESCRIPTION
I've updated the tests for  the routing of incoming HTTP authentication requests. 

Some notes:
-  Adding `HasTraits` as parent class to the `AuthenticatorSettings` class was necessary to enable traitlets and get the tests running. There is a very small chance this may break integration with JupyterHub, but the probability is small enough that I'm not concerned. If it is an issue, we will discover it when we run integration testing.
- Enabling full support for calling  `BaseHandler.redirect` requires spinning up a mock DB. I went down the rabbit hole a bit, and the process got much too complicated. Instead, I patched the `redirect` calls and tested they are being passed the correct destination URL.
- Fully authenticating valid users requires setting cookies and redirecting to the JupyterHub server's base url. Dealing with cookies was fairly easy (you can patch the function calls in the same way as the `redirect` method). However, I couldn't figure out how to mock the final destination URL. It's accessed in the code as `BaseHandler.hub.server.base_url` but I'm not clear what object types `hub` or `server` should be.