### PR TITLE
Makes default settings generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ Update the `authenticator_class` option in your Jupyter configuration file to re
 To enable basic authentication capabilities and request routing, specify the `RemoteUserAuthenticator` class:
 
 ```bash
-c.JupyterHub.authenticator_class = 'crc_jupyter_auth.RemoteUserAuthenticator'
+c.JupyterHub.authenticator_class = "crc_jupyter_auth.RemoteUserAuthenticator"
 ```
 
 To enable the same functionality plus local account management, use `RemoteUserLocalAuthenticator`:
 
 ```bash
-c.JupyterHub.authenticator_class = 'crc_jupyter_auth.RemoteUserLocalAuthenticator'
+c.JupyterHub.authenticator_class = "crc_jupyter_auth.RemoteUserLocalAuthenticator"
 ```
 
 The `RemoteUserLocalAuthenticator` class provides the same authentication functionality
@@ -58,13 +58,13 @@ Otherwise, the user is redirected.
 The HTTP header names and failure redirects are configurable via the Jupyter settings file.
 Setting names and default values are provided in the table below:
 
-| Setting Name        | Default                                       | Description                                                |
-|---------------------|-----------------------------------------------|------------------------------------------------------------|
-| `header_name`       | `Cn`                                          | HTTP header name to inspect for the authenticated username |
-| `header_vpn`        | `isMemberOf`                                  | HTTP header name to inspect for the user VPN role(s).      |
-| `required_vpn_role` | `SAM-SSLVPNSAMUsers`                          | Required VPN role for accessing the service.               |
-| `user_redirect`     | `https://crc.pitt.edu/Access-CRC-Web-Portals` | Url to redirect to if user has no home directory.          |
-| `vpn_redirect`      | `https://crc.pitt.edu/Access-CRC-Web-Portals` | Url to redirect to if user is missing necessary VPN role.  |
+| Setting Name            | Default                | Description                                                                                |
+|-------------------------|------------------------|--------------------------------------------------------------------------------------------|
+| `username_header`       | `"Cn"`                 | HTTP header name to inspect for the authenticated username                                 |
+| `vpn_header`            | `"isMemberOf"`         | HTTP header name to inspect for the user VPN role(s).                                      |
+| `required_vpn_role`     | `"SAM-SSLVPNSAMUsers"` | Required VPN role for accessing the service.                                               |
+| `missing_user_redirect` | `""`                   | Url to redirect to if user has no home directory. Defaults to 404 if empty string.         |
+| `missing_role_redirect` | `""`                   | Url to redirect to if user is missing necessary VPN role. Defaults to 404 if empty string. |
 
 ## Architecture and Security Recommendations
 

--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ Otherwise, the user is redirected.
 The HTTP header names and failure redirects are configurable via the Jupyter settings file.
 Setting names and default values are provided in the table below:
 
-| Setting Name            | Default                | Description                                                                                |
-|-------------------------|------------------------|--------------------------------------------------------------------------------------------|
-| `username_header`       | `"Cn"`                 | HTTP header name to inspect for the authenticated username                                 |
-| `vpn_header`            | `"isMemberOf"`         | HTTP header name to inspect for the user VPN role(s).                                      |
-| `required_vpn_role`     | `"SAM-SSLVPNSAMUsers"` | Required VPN role for accessing the service.                                               |
-| `missing_user_redirect` | `""`                   | Url to redirect to if user has no home directory. Defaults to 404 if empty string.         |
-| `missing_role_redirect` | `""`                   | Url to redirect to if user is missing necessary VPN role. Defaults to 404 if empty string. |
+| Setting Name            | Default        | Description                                                                                |
+|-------------------------|----------------|--------------------------------------------------------------------------------------------|
+| `username_header`       | `"Cn"`         | HTTP header name to inspect for the authenticated username                                 |
+| `vpn_header`            | `"isMemberOf"` | HTTP header name to inspect for the user VPN role(s).                                      |
+| `required_vpn_role`     | `""`           | Required VPN role for accessing the service. Ignored if an empty string.                   |
+| `missing_user_redirect` | `""`           | Url to redirect to if user has no home directory. Defaults to 404 if empty string.         |
+| `missing_role_redirect` | `""`           | Url to redirect to if user is missing necessary VPN role. Defaults to 404 if empty string. |
 
 ## Architecture and Security Recommendations
 

--- a/crc_jupyter_auth/remote_user_auth.py
+++ b/crc_jupyter_auth/remote_user_auth.py
@@ -35,23 +35,23 @@ class RemoteUserLoginHandler(BaseHandler):
         """
 
         # Check for username in header information
-        header_name = self.authenticator.header_name
+        header_name = self.authenticator.username_header
         remote_user = self.request.headers.get(header_name, "").lower().strip()
         if remote_user == "":
             raise web.HTTPError(401)
 
         # Check for necessary VPN role using request headers
         # Multiple roles are delimited by a semicolon
-        header_vpn = self.authenticator.header_vpn
+        header_vpn = self.authenticator.vpn_header
         remote_roles = self.request.headers.get(header_vpn, "").strip().split(';')
         if self.authenticator.required_vpn_role not in remote_roles:
-            self.redirect_or_raise(self.authenticator.vpn_redirect)
+            self.redirect_or_raise(self.authenticator.missing_role_redirect)
             return
 
         # Require the user has an existing home directory
         user_home_dir = os.path.expanduser('~{}'.format(remote_user))
         if not os.path.exists(user_home_dir):
-            self.redirect_or_raise(self.authenticator.user_redirect)
+            self.redirect_or_raise(self.authenticator.missing_user_redirect)
             return
 
         # Facilitate user authentication
@@ -85,12 +85,12 @@ class AuthenticatorSettings(HasTraits):
     deployment via the JupyterHub configuration file.
     """
 
-    header_name = Unicode(
+    username_header = Unicode(
         default_value='Cn',
         config=True,
         help="HTTP header to inspect for the authenticated username.")
 
-    header_vpn = Unicode(
+    vpn_header = Unicode(
         default_value='isMemberOf',
         config=True,
         help="HTTP header to inspect for user VPN role(s).")
@@ -100,12 +100,12 @@ class AuthenticatorSettings(HasTraits):
         config=True,
         help="Required VPN role for accessing the service.")
 
-    user_redirect = Unicode(
+    missing_user_redirect = Unicode(
         default_value='https://crc.pitt.edu/Access-CRC-Web-Portals',
         config=True,
         help="Url to redirect to if user has no home directory.")
 
-    vpn_redirect = Unicode(
+    missing_role_redirect = Unicode(
         default_value='https://crc.pitt.edu/Access-CRC-Web-Portals',
         config=True,
         help="Url to redirect to if user is missing necessary VPN role.")

--- a/crc_jupyter_auth/remote_user_auth.py
+++ b/crc_jupyter_auth/remote_user_auth.py
@@ -44,7 +44,8 @@ class RemoteUserLoginHandler(BaseHandler):
         # Multiple roles are delimited by a semicolon
         header_vpn = self.authenticator.vpn_header
         remote_roles = self.request.headers.get(header_vpn, "").strip().split(';')
-        if self.authenticator.required_vpn_role not in remote_roles:
+        required_role = self.authenticator.required_vpn_role
+        if required_role and (required_role not in remote_roles):
             self.redirect_or_raise(self.authenticator.missing_role_redirect)
             return
 
@@ -96,17 +97,17 @@ class AuthenticatorSettings(HasTraits):
         help="HTTP header to inspect for user VPN role(s).")
 
     required_vpn_role = Unicode(
-        default_value='SAM-SSLVPNSAMUsers',
+        default_value='',
         config=True,
         help="Required VPN role for accessing the service.")
 
     missing_user_redirect = Unicode(
-        default_value='https://crc.pitt.edu/Access-CRC-Web-Portals',
+        default_value='',
         config=True,
         help="Url to redirect to if user has no home directory.")
 
     missing_role_redirect = Unicode(
-        default_value='https://crc.pitt.edu/Access-CRC-Web-Portals',
+        default_value='',
         config=True,
         help="Url to redirect to if user is missing necessary VPN role.")
 

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -1,0 +1,29 @@
+"""Test user authentication classes relay user login handling to the ``RemoteUserLoginHandler``."""
+
+from unittest import TestCase
+
+from jupyterhub.auth import Authenticator
+
+from crc_jupyter_auth import RemoteUserAuthenticator, RemoteUserLocalAuthenticator
+from crc_jupyter_auth.remote_user_auth import RemoteUserLoginHandler
+
+
+class HandlerRegistration(TestCase):
+    """Test authentication classes use the ``RemoteUserLoginHandler`` to route login requests"""
+
+    def run_test_on_authenticator(self, authenticator: Authenticator) -> None:
+        """Assert the given authenticator routes ``/login`` traffic using the ``RemoteUserLoginHandler`` class"""
+
+        handlers_list = authenticator.get_handlers(app=None)
+        handlers_dict = dict(*zip(handlers_list))
+        self.assertIs(RemoteUserLoginHandler, handlers_dict['/login'])
+
+    def test_user_authenticator(self) -> None:
+        """Test the ``RemoteUserAuthenticator`` routes traffic using the ``RemoteUserLoginHandler`` handler"""
+
+        self.run_test_on_authenticator(RemoteUserAuthenticator())
+
+    def test_local_authenticator(self) -> None:
+        """Test the ``RemoteUserLocalAuthenticator`` routes traffic using the ``RemoteUserLoginHandler`` handler"""
+
+        self.run_test_on_authenticator(RemoteUserLocalAuthenticator())

--- a/tests/test_request_routing.py
+++ b/tests/test_request_routing.py
@@ -63,7 +63,7 @@ class RequestRouting(TestCase):
 
         # Create an HTTP request with a blank username
         authenticator = RemoteUserAuthenticator()
-        request_handler = self.create_http_request_handler(authenticator, {authenticator.header_name: ''})
+        request_handler = self.create_http_request_handler(authenticator, {authenticator.username_header: ''})
 
         with self.assertRaises(web.HTTPError) as http_exception:
             request_handler.get()
@@ -72,42 +72,42 @@ class RequestRouting(TestCase):
 
     @patch.object(RemoteUserLoginHandler, 'redirect', return_value=None)
     def test_missing_vpn_role(self, mock_redirect_call: MagicMock) -> None:
-        """Test users are redirected to the ``vpn_redirect`` url for missing VPN roles"""
+        """Test users are redirected to the ``missing_role_redirect`` url for missing VPN roles"""
 
         # Create an HTTP request with a valid username but missing VPN information
         authenticator = RemoteUserAuthenticator()
-        request_handler = self.create_http_request_handler(authenticator, {authenticator.header_name: 'username'})
+        request_handler = self.create_http_request_handler(authenticator, {authenticator.username_header: 'username'})
         request_handler.get()
 
-        mock_redirect_call.assert_called_once_with(authenticator.vpn_redirect)
+        mock_redirect_call.assert_called_once_with(authenticator.missing_role_redirect)
 
     @patch.object(RemoteUserLoginHandler, 'redirect', return_value=None)
     def test_incorrect_vpn_role(self, mock_redirect_call: MagicMock) -> None:
-        """Test users are redirected to the ``vpn_redirect`` url for incorrect VPN roles"""
+        """Test users are redirected to the ``missing_role_redirect`` url for incorrect VPN roles"""
 
         # Create an HTTP request with a valid username and invalid VPN information
         authenticator = RemoteUserAuthenticator()
         header_data = {
-            authenticator.header_name: 'username',
-            authenticator.header_vpn: 'FAKEROLE1;FAKEROLE2'
+            authenticator.username_header: 'username',
+            authenticator.vpn_header: 'FAKEROLE1;FAKEROLE2'
         }
 
         request_handler = self.create_http_request_handler(authenticator, header_data)
         request_handler.get()
 
         # Make sure the user was redirected to the correct location
-        mock_redirect_call.assert_called_once_with(authenticator.vpn_redirect)
+        mock_redirect_call.assert_called_once_with(authenticator.missing_role_redirect)
 
     def test_blank_vpn_settings_404(self) -> None:
-        """Test a 404 is raised when ``vpn_redirect`` is configured to a blank string"""
+        """Test a 404 is raised when ``missing_role_redirect`` is configured to a blank string"""
 
         # Create an HTTP request with a valid username but missing VPN information
-        # This will cause a redirect to the ``vpn_redirect`` url
+        # This will cause a redirect to the ``missing_role_redirect`` url
         authenticator = RemoteUserAuthenticator()
-        request_handler = self.create_http_request_handler(authenticator, {authenticator.header_name: 'username'})
+        request_handler = self.create_http_request_handler(authenticator, {authenticator.username_header: 'username'})
 
-        # Modify the ``vpn_redirect`` url to be a blank string and process the request
-        request_handler.authenticator.vpn_redirect = ''
+        # Modify the ``missing_role_redirect`` url to be a blank string and process the request
+        request_handler.authenticator.missing_role_redirect = ''
         with self.assertRaises(web.HTTPError) as http_exception:
             request_handler.get()
 
@@ -116,32 +116,32 @@ class RequestRouting(TestCase):
     @patch('os.path.exists', lambda path: False)
     @patch.object(RemoteUserLoginHandler, 'redirect', return_value=None)
     def test_missing_home_dir_redirect(self, mock_redirect_call: MagicMock) -> None:
-        """Test users are redirected to the ``user_redirect`` url if they do not have a home directory"""
+        """Test users are redirected to the ``missing_user_redirect`` url if they do not have a home directory"""
 
         authenticator = RemoteUserAuthenticator()
         header_data = {
-            authenticator.header_name: 'username',
-            authenticator.header_vpn: authenticator.required_vpn_role
+            authenticator.username_header: 'username',
+            authenticator.vpn_header: authenticator.required_vpn_role
         }
 
         request_handler = self.create_http_request_handler(authenticator, header_data)
         request_handler.get()
 
-        mock_redirect_call.assert_called_once_with(authenticator.user_redirect)
+        mock_redirect_call.assert_called_once_with(authenticator.missing_user_redirect)
 
     @patch('os.path.exists', lambda path: False)
     def test_blank_home_dir_settings_404(self) -> None:
-        """Test a 404 is raised when ``user_redirect`` is configured to a blank string"""
+        """Test a 404 is raised when ``missing_user_redirect`` is configured to a blank string"""
 
         authenticator = RemoteUserAuthenticator()
         header_data = {
-            authenticator.header_name: 'username',
-            authenticator.header_vpn: authenticator.required_vpn_role
+            authenticator.username_header: 'username',
+            authenticator.vpn_header: authenticator.required_vpn_role
         }
 
-        # Modify the ``vpn_redirect`` url to be a blank string and process the request
+        # Modify the ``missing_role_redirect`` url to be a blank string and process the request
         request_handler = self.create_http_request_handler(authenticator, header_data)
-        request_handler.authenticator.user_redirect = ''
+        request_handler.authenticator.missing_user_redirect = ''
 
         with self.assertRaises(web.HTTPError) as http_exception:
             request_handler.get()


### PR DESCRIPTION
As a general engineering principle, it's better to keep deployment-specific configurations separate from the core application source code. This PR updates settings values to be generic in nature, and expects users to configure the application after install. Settings names have also been renamed for better clarity.