### PR TITLE
Bumps minor version in required Python version

### DIFF
--- a/crc_jupyter_auth/__init__.py
+++ b/crc_jupyter_auth/__init__.py
@@ -2,6 +2,6 @@
 
 from .remote_user_auth import RemoteUserAuthenticator, RemoteUserLocalAuthenticator
 
-__version__ = '0.5.0'
+__version__ = '0.5.1'
 __author__ = 'Pitt Center for Research Computing'
 __license__ = 'GNU GPL V3'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "crc_jupyter_auth"
 dynamic = ["version"]
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 authors = [{ name = "Pitt Center for Research Computing" }]
 license = { file = "LICENCE.txt" }
 readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
Drops support for Python 3.6

Python 3.6 was never really supported to begin with. The `pyproject.toml` file required `python>=3.6` **and** `setuptools>=61.2`. These two requirements are not compatible. Setuptools 60+ is only available for Python 3.7 and above. Issue #53 also points out the package test suite does not cover Python 3.6 anyways.

Resolves #53