### PR TITLE
Bumps version for setup-python action

### DIFF
--- a/.github/workflows/PackageTest.yml
+++ b/.github/workflows/PackageTest.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
The `setup-python@v1` action uses deprecated features and will stop working soon. This PR upgrades to `setup-python@v4`