### PR TITLE
Adds /legacy to PyPi URL

### DIFF
--- a/.github/workflows/PackagePublish.yml
+++ b/.github/workflows/PackagePublish.yml
@@ -63,7 +63,7 @@ jobs:
         include:
           - host: https://py00.crc.pitt.edu
             environment: publish-h2p
-          - host: https://upload.pypi.org/
+          - host: https://upload.pypi.org/legacy/
             environment: publish-pypi
 
     steps:


### PR DESCRIPTION
Judging by the [error log](https://github.com/pitt-crc/Jupyter-Authenticator/actions/runs/4287555818/jobs/7468566079#step:4:52), it looks like I had the wrong URL.