### PR TITLE
Update PackagePublish.yml

### DIFF
--- a/.github/workflows/PackagePublish.yml
+++ b/.github/workflows/PackagePublish.yml
@@ -77,6 +77,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: true
-          repository_url: ${{ matrix.host }}
+          repository-url: ${{ matrix.host }}
           user: ${{ secrets.REPO_USER }}
           password: ${{ secrets.REPO_PASSWORD }}


### PR DESCRIPTION
The `pypa/gh-action-pypi-publish` action is switching to kebab syntax. This PR updates to the new syntax.