### PR TITLE
Adds CI job for improved branch protection

### DIFF
--- a/.github/workflows/PackageTest.yml
+++ b/.github/workflows/PackageTest.yml
@@ -6,7 +6,7 @@ on:
   push:
 
 jobs:
-  python_tests:
+  tests:
     name: Run Tests
     runs-on: ubuntu-latest
     strategy:
@@ -38,10 +38,21 @@ jobs:
         env:
           CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
+  # Use this job for branch protection rules
+  report-test-status:
+    name: Report Test Status
+    runs-on: ubuntu-latest
+    needs: tests
+    if: always()
+    steps:
+      - name: Check build status
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1
+
   codacy-coverage-reporter:
     name: Report code coverage
     runs-on: ubuntu-latest
-    needs: python_tests
+    needs: tests
     steps:
 
       # Tell codacy we are done reporting test coverage


### PR DESCRIPTION
When one or more test matrix jobs fail the Codacy report job is skipped. This allows PRs o be merged in even with failing tests. To address the problem, I've added a dedicated job for use with branch protections. 