### PR TITLE
Updates CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,17 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 10
-    groups:
-      python-dependencies:
-        patterns:
-          - "*"
+    open-pull-requests-limit: 100
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 100
     groups:
       actions-dependencies:
         patterns:

--- a/.github/workflows/CodeQL.yml
+++ b/.github/workflows/CodeQL.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: 25 5 * * 0
+    - cron: 0 7 1 * *
 
 jobs:
   analyze:
@@ -23,16 +23,15 @@ jobs:
         language: [ python ]
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: ${{ matrix.language }}
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
-      with:
-        category: /language:${{matrix.language}}
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: /language:${{matrix.language}}

--- a/.github/workflows/PackagePublish.yml
+++ b/.github/workflows/PackagePublish.yml
@@ -31,6 +31,9 @@ jobs:
             environment: publish-pypi
 
     steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -41,15 +44,12 @@ jobs:
         with:
           virtualenvs-create: false
 
-      - name: Checkout source
-        uses: actions/checkout@v3
-
       # Get the new package version from the release tag
-      # Release tags are expected to start with "refs/tags/v", so the first 11 characters are stripped
+      # Git release tags are expected to start with "refs/tags/v"
       - name: Set package version
         run: |
           release_tag=${{github.ref}}
-          poetry version "${release_tag:11}"
+          poetry version "${release_tag#refs/tags/v}"
 
       - name: Build package
         run: poetry build -v
@@ -57,7 +57,7 @@ jobs:
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          verbose: true
+          print-hash: true
           repository-url: ${{ matrix.host }}
           user: ${{ secrets.REPO_USER }}
           password: ${{ secrets.REPO_PASSWORD }}

--- a/.github/workflows/PackageTest.yml
+++ b/.github/workflows/PackageTest.yml
@@ -1,9 +1,11 @@
-name: Tests
+name: Test Package
 
 on:
   workflow_dispatch:
   workflow_call:
   push:
+  schedule:
+    - cron: 0 7 1,15 * *
 
 jobs:
   run-tests:
@@ -12,10 +14,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
 
     steps:
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
@@ -25,45 +30,41 @@ jobs:
         with:
           virtualenvs-create: false
 
-      - name: Checkout source
-        uses: actions/checkout@v3
-
-      - name: Install package dependencies
+      - name: Install dependencies
         run: poetry install --with tests
 
       - name: Run tests with coverage
         run: |
-          coverage run -m unittest discover 
-          coverage report --omit="tests/*"
-          coverage xml --omit="tests/*" -o report_${{ matrix.python-version }}.xml
+          poetry run coverage run -m unittest discover 
+          poetry run coverage report --omit="tests/*"
+          poetry run coverage xml --omit="tests/*" -o coverage.xml
 
-      # Report test coverage to codacy for the python version being tested
+      # Report partial coverage results to codacy for the current python version
       - name: Report partial coverage results
         if: github.event_name != 'release'
-        run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report --partial -l Python -r report_${{ matrix.python-version }}.xml
+        run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report --partial -l Python -r coverage.xml
+        env:
+          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+
+  # Tell codacy we are done reporting test coverage
+  report-code-coverage:
+    name: Report Coverage
+    if: github.event_name != 'release'
+    needs: run-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Finish reporting coverage
+        run: bash <(curl -Ls https://coverage.codacy.com/get.sh) final
         env:
           CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
   # Use this job for branch protection rules
   report-test-status:
     name: Report Test Status
-    runs-on: ubuntu-latest
-    needs: run-tests
     if: always()
+    needs: run-tests
+    runs-on: ubuntu-latest
     steps:
       - name: Check build status
         if: ${{ contains(needs.*.result, 'failure') }}
         run: exit 1
-
-  # Tell codacy we are done reporting test coverage
-  report-code-coverage:
-    name: Report Coverage
-    runs-on: ubuntu-latest
-    needs: run-tests
-    if: github.event_name != 'release'
-    steps:
-      - name: Finish reporting coverage
-        shell: bash
-        run: bash <(curl -Ls https://coverage.codacy.com/get.sh) final
-        env:
-          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}


### PR DESCRIPTION
This PR is part of a general update designed to standardize and improve CI across the GitHub organization. Changes include:

  - CodeQL scans are now run monthly at 7 AM
  - Tests are now also run twice a month
  - Python dependencies are grouped into a single update
  - Tests are run on Python 3.8 through 3.11
  - Poetry is installed using a dedicated action

