### PR TITLE
User Home Dir Check Removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Setting names and default values are provided in the table below:
 | `username_header`       | `"Cn"`         | HTTP header name to inspect for the authenticated username         -                          |
 | `vpn_header`            | `"isMemberOf"` | HTTP header name to inspect for the user VPN role(s).                                         |
 | `required_vpn_role`     | `""`           | Required VPN role for accessing the service. Ignored if an empty string.                      |
-| `missing_user_redirect` | `""`           | Redirect URL if the user has no home directory. Defaults to 404 if empty string.              |
 | `missing_role_redirect` | `""`           | Redirect URL if the user is missing the required VPN header. Defaults to 404 if empty string. |
 
 To modify a settings value, use the `c.Authenticator` object in the configuration file.

--- a/crc_jupyter_auth/remote_user_auth.py
+++ b/crc_jupyter_auth/remote_user_auth.py
@@ -48,12 +48,6 @@ class RemoteUserLoginHandler(BaseHandler):
             self.redirect_or_raise(self.authenticator.missing_role_redirect)
             return
 
-        # Check if the user has an existing home directory
-        user_home_dir = os.path.expanduser('~{}'.format(remote_user))
-        if not os.path.exists(user_home_dir):
-            self.redirect_or_raise(self.authenticator.missing_user_redirect)
-            return
-
         # Facilitate user authentication
         user = self.user_from_username(remote_user)
         self.set_login_cookie(user)
@@ -99,11 +93,6 @@ class AuthenticatorSettings(HasTraits):
         default_value='',
         config=True,
         help="Required VPN role for accessing the service.")
-
-    missing_user_redirect = Unicode(
-        default_value='',
-        config=True,
-        help="Url to redirect to if the user has no home directory.")
 
     missing_role_redirect = Unicode(
         default_value='',

--- a/tests/test_request_routing.py
+++ b/tests/test_request_routing.py
@@ -143,28 +143,3 @@ class RoutingByVpnRole(TestUtils, TestCase):
         request_handler.get()
 
         mock_redirect_call.assert_called_once_with(request_handler.authenticator.missing_role_redirect)
-
-
-class RoutingByHomeDir(TestUtils, TestCase):
-    """Test users without a home directory are redirect to the URL configured in settings"""
-
-    @patch('os.path.exists', lambda path: False)
-    @patch.object(RemoteUserLoginHandler, 'redirect', return_value=None)
-    def test_missing_home_dir_redirect(self, mock_redirect_call: MagicMock) -> None:
-        """Test users are redirected to the ``missing_user_redirect`` URL if they do not have a home directory"""
-
-        request_handler = self.create_http_request_handler({AuthenticatorSettings().username_header: 'username'})
-        request_handler.authenticator.missing_user_redirect = 'www.google.com'
-        request_handler.get()
-
-        mock_redirect_call.assert_called_once_with(request_handler.authenticator.missing_user_redirect)
-
-    @patch('os.path.exists', lambda path: False)
-    def test_missing_home_dir_redirect_404(self) -> None:
-        """Test a 404 is raised when ``missing_user_redirect`` is configured to a blank string"""
-
-        request_handler = self.create_http_request_handler({AuthenticatorSettings().username_header: 'username'})
-        with self.assertRaises(web.HTTPError) as http_exception:
-            request_handler.get()
-
-        self.assertEqual(404, http_exception.exception.status_code)


### PR DESCRIPTION
Removing the part of the code checking for the presence of a home directory for the authenticated user. This was dedicated for Jupyterhub running on a host machine before; however, we changed the implementation to containerized Jupyterhub which provisions a unified container for each user with its dedicated home dir.
